### PR TITLE
fix(index): update syntax to match latest rc3

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "css-loader": "^0.26.0",
-    "extract-text-webpack-plugin": "^2.0.0-beta",
+    "extract-text-webpack-plugin": "^2.0.0-rc.3",
     "resolve-url-loader": "^1.6.0",
     "style-loader": "^0.13.1"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,7 @@ export = function css({ filename = '[name].css', allChunks = false, sourceMap = 
         rules: get(this, 'module.rules', []).concat([{
           test,
           use: extractCss ?
-            extractText.extract({ fallbackLoader: loaders[0], loader: loaders.slice(1) }) : 
+            extractText.extract({ fallback: loaders[0], use: loaders.slice(1) }) :
             loaders
         }])
       },


### PR DESCRIPTION
Latest RC (RC3) of extract-text-webpack-plugin gives a warning when using the fallbackLoader and loader namings. Also updated the dependency to the latest RC.

See: https://github.com/webpack-contrib/extract-text-webpack-plugin/releases/tag/v2.0.0-rc.3